### PR TITLE
fix: correct database path for chapter controller

### DIFF
--- a/website/controllers/chapterController.js
+++ b/website/controllers/chapterController.js
@@ -4,7 +4,11 @@ import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const db = new Database(path.join(__dirname, '../db/allfaithsonfire.db'));
+// The database file lives in the repository root. The previous relative path
+// pointed to `website/db/allfaithsonfire.db`, which does not exist and causes
+// runtime failures when the site attempts to open the SQLite database. Adjust
+// the path to correctly resolve the database from the controller directory.
+const db = new Database(path.join(__dirname, '../../allfaithsonfire.db'));
 
 export function getChapter(req, res) {
   const stmt = db.prepare(`


### PR DESCRIPTION
## Summary
- fix database path in chapter controller so server can find `allfaithsonfire.db`

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_688bc1e2c0a08333beafd9422c3112c2