### PR TITLE
refactor: simplify chapter query

### DIFF
--- a/website/controllers/chapterController.js
+++ b/website/controllers/chapterController.js
@@ -12,14 +12,9 @@ const db = new Database(path.join(__dirname, '../../allfaithsonfire.db'));
 
 export function getChapter(req, res) {
   const stmt = db.prepare(`
-    SELECT c.id, c.title, c.filename, c.created_at, 
-           b.title AS book_title,
-           m.text AS moral, r.text AS redemption, co.text AS consequence
+    SELECT c.id, c.title, c.created_at, b.title AS book_title
     FROM chapters c
     JOIN books b ON b.id = c.book_id
-    LEFT JOIN morals m ON m.id = c.moral_id
-    LEFT JOIN redemptions r ON r.id = c.redemption_id
-    LEFT JOIN consequences co ON co.id = c.consequence_id
     WHERE c.id = ?
   `);
   const chapter = stmt.get(req.params.id);

--- a/website/views/chapter.ejs
+++ b/website/views/chapter.ejs
@@ -2,9 +2,6 @@
 <head><title><%= chapter.title %></title></head>
 <body>
 <h1><%= chapter.book_title %>: <%= chapter.title %></h1>
-<p><strong>Moral:</strong> <%= chapter.moral || '—' %></p>
-<p><strong>Consequence:</strong> <%= chapter.consequence || '—' %></p>
-<p><strong>Redemption:</strong> <%= chapter.redemption || '—' %></p>
 <ul>
 <% verses.forEach(v => { %>
   <li><strong><%= v.verse_number %></strong>: <%= v.text %></li>

--- a/website/views/chapter_snippet.ejs
+++ b/website/views/chapter_snippet.ejs
@@ -5,16 +5,3 @@
   <p><strong><%= v.verse_number %></strong> <%= v.text %></p>
 <% }) %>
 <hr />
-<% if (chapter.moral || chapter.consequence || chapter.redemption) { %>
-  <div class="chapter-meta">
-    <% if (chapter.moral) { %>
-      <p><strong>Moral:</strong> <%= chapter.moral %></p>
-    <% } %>
-    <% if (chapter.consequence) { %>
-      <p><strong>Consequence of Ignoring:</strong> <%= chapter.consequence %></p>
-    <% } %>
-    <% if (chapter.redemption) { %>
-      <p><strong>Redemption Path:</strong> <%= chapter.redemption %></p>
-    <% } %>
-  </div>
-<% } %>


### PR DESCRIPTION
## Summary
- remove LEFT JOIN clauses and unused fields from chapter query
- strip moral/consequence/redemption references from chapter templates

## Testing
- `npm install --prefix website` *(fails: 403 Forbidden - GET https://registry.npmjs.org/better-sqlite3)*
- `node website/server.js` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688bea355ab883339f9636f662e50d62